### PR TITLE
Remove pergunta sobre url da foto

### DIFF
--- a/lib/tasks/new_profile.rake
+++ b/lib/tasks/new_profile.rake
@@ -15,14 +15,9 @@ module NewProfileTask
     def run
       # Required fields
       while (name = ask('Your full name:')).nil?; end
-      while (image = ask('URL to an image of you (tip: type in your email to get your gravatar image)')).nil?; end
       while (job_title = ask('Your job title:')).nil?; end
       while (slug = ask('Your @helabs.com.br username:')).nil?; end
       while (location = ask("Your latitude and longitude e.g. \e[33m-22.918747, -43.177080\e[0m\:")).nil?; end
-
-      if image =~ /[\w+]+@[\w|\.]+/
-        image ='http://gravatar.com/avatar/' + Digest::MD5.hexdigest(image) + '?s=160'
-      end
 
       job_cool = ask("A \"cool\" job title to be shown on your profile page (Defaults to the job title)")
       twitter  = ask('Your twitter handle:')
@@ -30,11 +25,12 @@ module NewProfileTask
       dribbble = ask('Your dribbble user:')
       behance  = ask('Your behance user:')
 
+      info_about_picture(name)
+
       vars = {
         full_name:           name,
         parameterized_name:  parametrized_name(name),
         slug:                slug,
-        image:               image,
         location:            location,
         job_title:           job_title,
         job_cool:            job_cool,
@@ -52,6 +48,7 @@ module NewProfileTask
     private
 
     def parametrized_name(name)
+      I18n.enforce_available_locales = false
       I18n.transliterate(name).gsub(' ', '-').downcase
     end
 
@@ -59,6 +56,14 @@ module NewProfileTask
       STDOUT.print "#{question} "
       answer = STDIN.gets.chomp.strip
       !answer.empty? && answer || opts[:default_value]
+    end
+
+    def info_about_picture(name)
+      puts "Your picture file name should be: #{yellow("time-#{parametrized_name(name)}.jpg")} and #{yellow("time-#{parametrized_name(name)}@2x.jpg")}."
+    end
+
+    def yellow(text)
+      "\e[33m#{text}\e[0m"
     end
   end
 end

--- a/lib/tasks/new_profile.rake
+++ b/lib/tasks/new_profile.rake
@@ -59,8 +59,17 @@ module NewProfileTask
     end
 
     def info_about_picture(name)
-      puts "Your picture file name should be: #{yellow("time-#{parametrized_name(name)}.jpg")} and #{yellow("time-#{parametrized_name(name)}@2x.jpg")}."
+      puts "Your photo file should be: #{image_of(name)} and #{image2x_of(name)}."
     end
+
+    def image_of(name)
+      yellow("/images/time/time-#{parametrized_name(name)}.jpg")
+    end
+
+    def image2x_of(name)
+      yellow("/images/time/time-#{parametrized_name(name)}@2x.jpg")
+    end
+
 
     def yellow(text)
       "\e[33m#{text}\e[0m"

--- a/lib/templates/new_profile-en.yml.erb
+++ b/lib/templates/new_profile-en.yml.erb
@@ -4,7 +4,8 @@ category: team
 # TODO: Remove the line below to skip the link to the user profile page or remove this comment
 permalink: "/en/our-team/<%= parameterized_name %>"
 pt: "/pt/nosso-time/<%= parameterized_name %>"
-image: "<%= image %>"
+image: "/images/time/time-<%= parameterized_name %>.jpg"
+image2x: "/images/time/time-<%= parameterized_name %>@2x.jpg"
 full_name: <%= full_name  %>
 slug: <%= slug %>
 location: <%= location %>

--- a/lib/templates/new_profile-pt.yml.erb
+++ b/lib/templates/new_profile-pt.yml.erb
@@ -4,7 +4,8 @@ category: time
 # TODO: Remove the line below to skip the link to the user profile page or remove this comment
 permalink: "/pt/nosso-time/<%= parameterized_name %>"
 en: "/en/our-team/<%= parameterized_name %>"
-image: "<%= image %>"
+image: "/images/time/time-<%= parameterized_name %>.jpg"
+image2x: "/images/time/time-<%= parameterized_name %>@2x.jpg"
 full_name: <%= full_name  %>
 slug: <%= slug %>
 location: <%= location %>

--- a/spec/lib/profile_builder_spec.rb
+++ b/spec/lib/profile_builder_spec.rb
@@ -8,7 +8,6 @@ describe ProfileBuilder do
           full_name:           'John Doe',
           parameterized_name:  'john-doe',
           slug:                'john',
-          image:               '/path/to/image.jpg',
           job_title:           'Developer',
           job_cool:            'Brew Master',
           location:            '-12.972532, -38.439881',
@@ -32,7 +31,8 @@ describe ProfileBuilder do
         it { expect(File).to exist(file_path) }
         it { expect(file_text).to match('permalink: "/pt/nosso-time/john-doe') }
         it { expect(file_text).to match('en: "/en/our-team/john-doe"') }
-        it { expect(file_text).to match('image: "/path/to/image.jpg"') }
+        it { expect(file_text).to match('image: "/images/time/time-john-doe.jpg"') }
+        it { expect(file_text).to match('image2x: "/images/time/time-john-doe@2x.jpg"') }
         it { expect(file_text).to match('full_name: John Doe') }
         it { expect(file_text).to match('job_title: Developer') }
         it { expect(file_text).to match('job_cool: Brew Master') }
@@ -75,7 +75,8 @@ describe ProfileBuilder do
         it { expect(File).to exist(file_path) }
         it { expect(file_text).to match('permalink: "/pt/nosso-time/\"') }
         it { expect(file_text).to match('en: "/en/our-team/\"') }
-        it { expect(file_text).to match('image: ""') }
+        it { expect(file_text).to match('image: "/images/time/time-.jpg"') }
+        it { expect(file_text).to match('image2x: "/images/time/time-@2x.jpg"') }
         it { expect(file_text).to match('full_name: \n') }
         it { expect(file_text).to match('job_title: \n') }
         it { expect(file_text).to match('job_cool: \n') }
@@ -95,7 +96,6 @@ describe ProfileBuilder do
           full_name:           'John Doe',
           parameterized_name:  'john-doe',
           slug:                'john',
-          image:               '/path/to/image.jpg',
           job_title:           'Developer',
           job_cool:            'Brew Master',
           location:            '-12.972532, -38.439881',
@@ -119,7 +119,8 @@ describe ProfileBuilder do
         it { expect(File).to exist(file_path) }
         it { expect(file_text).to match('permalink: "/en/our-team/john-doe"') }
         it { expect(file_text).to match('pt: "/pt/nosso-time/john-doe"') }
-        it { expect(file_text).to match('image: "/path/to/image.jpg"') }
+        it { expect(file_text).to match('image: "/images/time/time-john-doe.jpg"') }
+        it { expect(file_text).to match('image2x: "/images/time/time-john-doe@2x.jpg"') }
         it { expect(file_text).to match('full_name: John Doe') }
         it { expect(file_text).to match('job_title: Developer') }
         it { expect(file_text).to match('job_cool: Brew Master') }
@@ -162,7 +163,8 @@ describe ProfileBuilder do
         it { expect(File).to exist(file_path) }
         it { expect(file_text).to match('permalink: "/en/our-team/\"') }
         it { expect(file_text).to match('pt: "/pt/nosso-time/\"') }
-        it { expect(file_text).to match('image: ""') }
+        it { expect(file_text).to match('image: "/images/time/time-.jpg"') }
+        it { expect(file_text).to match('image2x: "/images/time/time-@2x.jpg"') }
         it { expect(file_text).to match('full_name: \n') }
         it { expect(file_text).to match('job_title: \n') }
         it { expect(file_text).to match('job_cool: \n') }


### PR DESCRIPTION
Nesse PR alterei a task `rake new_profile` para não mais perguntar a url da foto e sim definir o nome das imagens baseado no nome e sobre nome do perfil sendo criado. 

Nesse formato ele seria mais `"opinionated"` ao invés de ficar esperando algo ser preenchido, ou seja, basta colocar as imagens com normal e 2x com o nome gerado pela task como pode ser visto abaixo.

Também tem relação com a issue #660 

<img width="1280" alt="screen shot 2015-10-28 at 14 58 34" src="https://cloud.githubusercontent.com/assets/27034/10796218/69c84068-7d84-11e5-8a16-56edfa22fefd.png">
