### PR TITLE
Removing H3 from footer address

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,6 @@
   <link href='http://fonts.googleapis.com/css?family=Lato:300,400,500,300italic,700|Open+Sans' rel='stylesheet' type='text/css'>
   <title>{{ page.title }} &mdash; HE:labs</title>
 
-  <meta http-equiv="content-language" content="pt-br">
   <meta http-equiv="content-type" content="text/html; charset=utf-8">
 
   <meta name="copyright" content="© 2014 HE:labs">
@@ -26,9 +25,11 @@
   <link href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.min.css" rel="stylesheet">
 
   {% if page.en %}
+  <meta http-equiv="content-language" content="pt-br">
   <link rel="alternate" href="http://helabs.com{{ page.en }}" hreflang="en" />
   <link rel="alternate" href="http://helabs.com{{ page.url }}" hreflang="pt-br" />
   {% else %}
+  <meta http-equiv="content-language" content="en">
   <link rel="alternate" href="http://helabs.com{{ page.url }}" hreflang="en" />
   <link rel="alternate" href="http://helabs.com{{ page.pt }}" hreflang="pt-br" />
   {% endif %}

--- a/_includes/offices.html
+++ b/_includes/offices.html
@@ -3,7 +3,7 @@
     <li class="rj-rio">
       <address>
         <a href="http://goo.gl/embem8" rel="nofollow external">
-          <h3>Rio de Janeiro</h3>
+          <span class="which-office">Rio de Janeiro</span>
           Rua da Glória 190, sala 1002<br>
           Glória<br>
           Rio de Janeiro - RJ<br>
@@ -19,7 +19,7 @@
     <li>
       <address>
         <a href="https://goo.gl/maps/Geuev" rel="nofollow external">
-          <h3>Miami</h3>
+          <span class="which-office">Miami</span>
           201 South Biscayne Blvd.<br>
           Suite#1200. Downtown Miami<br>
           Miami - FL<br>

--- a/_includes/offices_en.html
+++ b/_includes/offices_en.html
@@ -3,7 +3,7 @@
     <li class="rj-rio">
       <address>
         <a href="http://goo.gl/embem8" rel="nofollow external">
-          <h3>Rio de Janeiro</h3>
+          <span class="which-office">Rio de Janeiro</span>
           Rua da Glória 190, room 1002<br>
           Glória<br>
           Rio de Janeiro - RJ<br>
@@ -19,7 +19,7 @@
     <li>
       <address>
         <a href="https://goo.gl/maps/Geuev" rel="nofollow external">
-          <h3>Miami</h3>
+          <span class="which-office">Miami</span>
           201 South Biscayne Blvd.<br>
           Suite#1200. Downtown Miami<br>
           Miami - FL<br>

--- a/_sass/core/_main.scss
+++ b/_sass/core/_main.scss
@@ -646,9 +646,9 @@ footer {
     text-transform: uppercase;
     margin: 7px 0 7px 0;
     color: #fff;
-		font-family: 'Lato', sans-serif;
-		font-size: 1.17em;
-		font-weight: bold;
+    font-family: 'Lato', sans-serif;
+    font-size: 1.17em;
+    font-weight: bold;
   }
 
   li.social-he-links {

--- a/_sass/core/_main.scss
+++ b/_sass/core/_main.scss
@@ -642,10 +642,13 @@ footer {
     display: block;
   }
 
-  h3 {
+  .which-office {
     text-transform: uppercase;
     margin: 7px 0 7px 0;
     color: #fff;
+		font-family: 'Lato', sans-serif;
+		font-size: 1.17em;
+		font-weight: bold;
   }
 
   li.social-he-links {


### PR DESCRIPTION
The words Rio, Miami, Janeiro we strong as our keywords, which doesn't add nothing to our SEO.  fixed by removing them from the h3 tag
https://www.google.com/webmasters/tools/keywords?hl=pt-BR&siteUrl=http://helabs.com/

Also fixed the `meta content-language`